### PR TITLE
PR4: Add styled advocates list with card components

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,18 +5,3 @@ require("whatwg-fetch");
 jest.mock("next/font/google", () => ({
   Inter: () => ({ className: "mocked-inter-font" }),
 }));
-
-// // Mock window.matchMedia
-// Object.defineProperty(window, "matchMedia", {
-//   writable: true,
-//   value: jest.fn().mockImplementation((query) => ({
-//     matches: false,
-//     media: query,
-//     onchange: null,
-//     addListener: jest.fn(), // deprecated
-//     removeListener: jest.fn(), // deprecated
-//     addEventListener: jest.fn(),
-//     removeEventListener: jest.fn(),
-//     dispatchEvent: jest.fn(),
-//   })),
-// });

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -38,7 +38,7 @@ export async function GET(
     const limitParam: string | null = url.searchParams.get("limit");
 
     const page = pageParam ? parseInt(pageParam) : 1;
-    const limit = limitParam ? parseInt(limitParam) : 10;
+    const limit = limitParam ? parseInt(limitParam) : 9;
 
     if (isNaN(page) || page < 1) {
       return NextResponse.json<ErrorResponseBody>(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,9 +22,13 @@ html {
   scroll-behavior: smooth;
 }
 
+#contentBody {
+  color: #91bfbfb0;
+}
+
 body {
   font-family: "Inter", monospace;
-  background-color: #f9fafb; /* default light mode background */
+  background-color: #91bfbf34; /* default light mode background */
   color: #111827; /** light mode text **/
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,9 +54,13 @@ h4,
 h5,
 h6 {
   font-weight: 600;
-  color: #111827;
+  /* color: #111827; */
+  color: #115e59;
   /* color: #9e1d53; */
 }
+
+/* bg-teal-100 dark:bg-teal-700 */
+/* text-teal-800 dark:text-teal-100 */
 
 .dark h1,
 .dark h2,
@@ -65,7 +69,14 @@ h6 {
 .dark h5,
 .dark h6 {
   /* color: #f9fafb; */
-  color: #22c55e;
+  /* color: #22c55e; */
+
+  color: #ccfbf1;
+
+  /* light teal: #ccfbf1 */
+  /* bg-teal-700: #0f766e
+  text-teal-800: #115e59
+  text-teal-100: #ccfbf1 */
 }
 
 .logo {
@@ -74,7 +85,8 @@ h6 {
 }
 
 .dark .logo {
-  color: #22c55e;
+  /* color: #22c55e; */
+  color: #115e59;
 }
 
 p {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,26 +33,37 @@ export default function RootLayout({
   testMode?: boolean;
 }): JSX.Element {
   const content = (
-    <>
+    <div className="flex flex-col min-h-screen w-full">
       <Navbar />
-      <main id="appContainer" className="max-w-7xl mx-auto p-6 rounded-3xl">
+      <main
+        id="appContainer"
+        className="flex-grow w-full max-w-7xl mx-auto p-6 rounded-3xl"
+      >
         {children}
       </main>
       <Footer />
-    </>
+    </div>
   );
 
   if (testMode) {
     return (
-      <div lang="en" className={inter.className}>
-        <div className="bg-gray-300 text-gray-800">{content}</div>
+      <div
+        lang="en"
+        className={`${inter.className} min-h-screen flex flex-col`}
+      >
+        <div className="bg-gray-300 text-gray-800 flex-grow">{content}</div>
       </div>
     );
   }
 
   return (
     <html lang="en" className={inter.className}>
-      <body className="bg-gray-300 text-gray-800">{content}</body>
+      <body
+        id="contentBody"
+        className="text-gray-800 min-h-screen flex flex-col"
+      >
+        {content}
+      </body>
     </html>
   );
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -42,8 +42,9 @@ describe("Home component", () => {
       throw new Error("Component was not rendered correctly");
     }
 
-    expect(component.getByText("John")).toBeInTheDocument();
-    expect(component.getByText("Doe")).toBeInTheDocument();
+    expect(component.getByText("John Doe")).toBeInTheDocument();
+    expect(component.getByText("New York")).toBeInTheDocument();
+    expect(component.getByText("MD")).toBeInTheDocument();
   });
 
   it("initial useEffect hydration of advocates", async () => {
@@ -52,8 +53,9 @@ describe("Home component", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("John")).toBeInTheDocument();
-      expect(screen.getByText("Doe")).toBeInTheDocument();
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+      expect(screen.getByText("New York")).toBeInTheDocument();
+      expect(screen.getByText("MD")).toBeInTheDocument();
     });
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,11 @@
 
 import { useEffect, useState } from "react";
 
+import { Advocate } from "@/types/advocates";
+
 /** components */
 import AdvocateCard from "@/components/AdvocateCard";
+import AdvocateList from "@/components/AdvocateList";
 
 /**
  * IMPROVEMENTS:
@@ -13,17 +16,6 @@ import AdvocateCard from "@/components/AdvocateCard";
  *  + implmeneted consistent styling using Tailwind
  *  + applicaiton is generally cleaned up and ready for new features
  */
-
-interface Advocate {
-  id: number;
-  firstName: string;
-  lastName: string;
-  city: string;
-  degree: string;
-  specialties: string[];
-  yearsOfExperience: number;
-  phoneNumber: number;
-}
 
 interface AdvocateAPIResponse {
   data: Advocate[];
@@ -188,9 +180,9 @@ export default function Home(): JSX.Element {
         </tbody>
       </table>
 
-      {/* advocate card example */}
       <div>
-        <AdvocateCard />
+        <p>Advocate List</p>
+        <AdvocateList advocates={filteredAdvocates as Advocate[]} />
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 import { Advocate } from "@/types/advocates";
 
 /** components */
-import AdvocateCard from "@/components/AdvocateCard";
 import AdvocateList from "@/components/AdvocateList";
 
 /**
@@ -84,55 +83,13 @@ export default function Home(): JSX.Element {
     setFilteredAdvocates(filteredAdvocates);
   };
 
-  /** as long as keys are strings, we ensure order */
-  const headersMap: Record<string, string> = {
-    firstName: "First Name",
-    lastName: "Last Name",
-    city: "City",
-    degree: "Degree",
-    specialties: "Specialties",
-    yearsOfExperience: "Experience",
-    phoneNumber: "Phone",
-  };
-
-  /**
-   * @param {string} header - The table header string
-   * @returns {JSX.Element} A <th> element with the header string
-   */
-  const tableHeaderCell = (header: string): JSX.Element => (
-    <th key={header} className="border border-gray-300 px-4 py-2">
-      {header}
-    </th>
-  );
-
-  /**
-   * Creates a <td> element with the value of the given advocate and key.
-   * @param {Advocate} advocate - The advocate object
-   * @param {keyof Advocate} key - The key of the advocate object
-   * @returns {JSX.Element} A <td> element with the value of the given advocate and key
-   */
-  const tableDataCell = (
-    advocate: Advocate,
-    key: keyof Advocate
-  ): JSX.Element => {
-    const cellValue = advocate[key];
-    return (
-      <td
-        key={`${advocate.id}-${key}`}
-        className="border border-gray-300 px-4 py-2"
-      >
-        {Array.isArray(cellValue) ? cellValue.join(", ") : cellValue}
-      </td>
-    );
-  };
-
   return (
     <div className="max-w-7xl mx-auto p-2">
       {/* TITLE SECTION */}
-      <h1 className="text-2xl font-bold mb-6">Solace Advocates Finder</h1>
+      <h1 className="text-2xl font-bold mb-4">Solace Advocates Finder</h1>
 
       {/* SEARCH SECTION */}
-      <div className="mb-10">
+      <div className="mb-7">
         <label htmlFor="searchbar" className="block text-md font-medium p-2">
           Search Advocates
         </label>
@@ -158,30 +115,7 @@ export default function Home(): JSX.Element {
         </div>
       )}
 
-      {/* ADVOCATES TABLE (will be own component) */}
-      <table className="w-full table-auto border-collapse border border-gray-400 shadow-sm">
-        <thead className="bg-gray-100 text-gray-700">
-          <tr>
-            {Object.values(headersMap).map((header) => {
-              return tableHeaderCell(header);
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
-              <tr key={advocate.id}>
-                {Object.keys(headersMap).map((headerKey) =>
-                  tableDataCell(advocate, headerKey as keyof Advocate)
-                )}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-
-      <div>
-        <p>Advocate List</p>
+      <div id="advocateListHolder" className="mx-2 p-2">
         <AdvocateList advocates={filteredAdvocates as Advocate[]} />
       </div>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useState } from "react";
 
+/** components */
+import AdvocateCard from "@/components/AdvocateCard";
+
 /**
  * IMPROVEMENTS:
  *  + ensure strong typing using TS
@@ -184,6 +187,11 @@ export default function Home(): JSX.Element {
           })}
         </tbody>
       </table>
+
+      {/* advocate card example */}
+      <div>
+        <AdvocateCard />
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,18 +86,21 @@ export default function Home(): JSX.Element {
   return (
     <div className="max-w-7xl mx-auto p-2">
       {/* TITLE SECTION */}
-      <h1 className="text-2xl font-bold mb-4">Solace Advocates Finder</h1>
+      <h1 className="text-3xl font-extrabold mb-4">Solace Advocates Finder</h1>
 
       {/* SEARCH SECTION */}
       <div className="mb-7">
-        <label htmlFor="searchbar" className="block text-md font-medium p-2">
+        <label
+          htmlFor="searchbar"
+          className="block text-md font-medium p-2 text-teal-900 dark:text-teal-300"
+        >
           Search Advocates
         </label>
         <input
           id="searchbar"
           type="text"
           // lets make this look a little nicer
-          className="w-full px-4 py-2 border border-gray-300 rounded-3xl focus:outline-none focus:ring-2 focus:ring-teal-500"
+          className="w-full px-4 text-teal-800 bg-teal-50 py-2 border border-gray-300 rounded-3xl focus:outline-none focus:ring-2 focus:ring-teal-500"
           placeholder="Search by name, city, or specialty..."
           value={searchTerm}
           onChange={handleSearchInputChange}
@@ -115,7 +118,7 @@ export default function Home(): JSX.Element {
         </div>
       )}
 
-      <div id="advocateListHolder" className="mx-2 p-2">
+      <div id="advocateListHolder" className="mx-4 p-2">
         <AdvocateList advocates={filteredAdvocates as Advocate[]} />
       </div>
     </div>

--- a/src/components/AdvocateCard.tsx
+++ b/src/components/AdvocateCard.tsx
@@ -47,10 +47,9 @@ export default function AdvocateCard({
 
   return (
     <>
-      <div className="mb-7"></div>
-      <div className="bg-white dark:bg-gray-600 shadow-md rounded-lg p-4 hover:shadow-lg transition-all duration-200 ease-in-out">
-        <div className="flex items-center mb-4">
-          <div className="w-16 h-16 bg-gray-300 dark:bg-gray-900 rounded-full flex-shrink-0"></div>
+      <div className="bg-white dark:bg-gray-600 hover:bg-teal-50 dark:hover:bg-teal-600 shadow-md rounded-lg p-4 cursor-pointer hover:shadow-xl transition-all duration-200 ease-in-out">
+        <div className="flex items-center mb-1">
+          <div className="w-20 h-20 bg-gray-300 dark:bg-gray-900 rounded-full flex-shrink-0"></div>
           <div className="ml-4">
             <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
               {name || "name"}
@@ -68,8 +67,8 @@ export default function AdvocateCard({
             Specialties
           </h3>
           <div className="flex flex-wrap gap-2">
-            {mockSpecialties &&
-              mockSpecialties.map((specialty, index) => (
+            {specialties &&
+              specialties.map((specialty, index) => (
                 <span
                   key={index}
                   className="px-2 py-1 bg-teal-100 dark:bg-teal-700 text-teal-800 dark:text-teal-100 rounded text-xs"

--- a/src/components/AdvocateCard.tsx
+++ b/src/components/AdvocateCard.tsx
@@ -1,0 +1,29 @@
+/**
+ * advocate card will contain
+ * -> name, degree, specialties, years of experience, city
+ */
+
+/** what props does this have? Make an interface */
+interface AdvocateCardProps {
+  name: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  city: string;
+}
+
+const AdvocateCard = ({
+  name,
+  degree,
+  specialties,
+  yearsOfExperience,
+  city,
+}: AdvocateCardProps): JSX.Element => {
+  return (
+    <div>
+      <h1>Advocate Card</h1>
+    </div>
+  );
+};
+
+export default AdvocateCard;

--- a/src/components/AdvocateCard.tsx
+++ b/src/components/AdvocateCard.tsx
@@ -19,9 +19,83 @@ const AdvocateCard = ({
   yearsOfExperience,
   city,
 }: AdvocateCardProps): JSX.Element => {
+  const mockSpecialties: string[] = [
+    "Bipolar",
+    "LGBTQ",
+    "Medication/Prescribing",
+    "Suicide History/Attempts",
+    "General Mental Health (anxiety, depression, stress, grief, life transitions)",
+    "Men's issues",
+    "Relationship Issues (family, friends, couple, etc)",
+    "Trauma & PTSD",
+    "Personality disorders",
+    "Personal growth",
+    "Substance use/abuse",
+    "Pediatrics",
+    // "Women's issues (post-partum, infertility, family planning)",
+    // "Chronic pain",
+    // "Weight loss & nutrition",
+    // "Eating disorders",
+    // "Diabetic Diet and nutrition",
+    // "Coaching (leadership, career, academic and wellness)",
+    // "Life coaching",
+    // "Obsessive-compulsive disorders",
+    // "Neuropsychological evaluations & testing (ADHD testing)",
+    // "Attention and Hyperactivity (ADHD)",
+    // "Sleep issues",
+    // "Schizophrenia and psychotic disorders",
+    // "Learning disorders",
+    // "Domestic abuse",
+  ];
+
   return (
     <div>
       <h1>Advocate Card</h1>
+      <div className="bg-white dark:bg-gray-200 shadow-xs rounded-lg p-4 hover:shadow-lg transition-all duration-1000 ease-in-out">
+        {/* Avatar and advocate info */}
+        <div className="flex items-center mb-4">
+          {/* maintain size even if parent becomes smaller */}
+          <div className="w-16 h-16 bg-gray-500 dark:bg-gray-700 rounded-full flex-shrink-0">
+            avatar
+          </div>
+          <div className="bg-gray-200 ml-4">
+            <h2 className="text-lg font-bold text-gray-800 dark:text-gray-800">
+              {name || "name"}
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-600">
+              {degree || "degree"}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-600">
+              {city || "city"}
+            </p>
+          </div>
+        </div>
+
+        {/* Specialty tags */}
+        <div className="mb-4">
+          <h3 className="text-sm font-semibold mb-2 text-teal-800 dark:text-teal-900">
+            Specialties
+          </h3>
+          <div className="flex flex-wrap p-3 gap-2">
+            {mockSpecialties &&
+              mockSpecialties.map((specialty: string, index: number) => {
+                return (
+                  <span
+                    key={index}
+                    className="px-2 py-1 bg-teal-100 dark:bg-teal-700 text-teal-1000 dark:text-teal-100 rounded text-xs"
+                  >
+                    {specialty}
+                  </span>
+                );
+              })}
+          </div>
+        </div>
+
+        {/* Years of experience */}
+        <p className="text-sm text-gray-600 dark:text-gray-900">
+          {yearsOfExperience || "yearsOfExperience: "} years of experience
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/components/AdvocateCard.tsx
+++ b/src/components/AdvocateCard.tsx
@@ -47,9 +47,9 @@ export default function AdvocateCard({
 
   return (
     <>
-      <div className="bg-white dark:bg-gray-600 hover:bg-teal-50 dark:hover:bg-teal-600 shadow-md rounded-lg p-4 cursor-pointer hover:shadow-xl transition-all duration-200 ease-in-out">
+      <div className="bg-white dark:bg-gray-600 hover:bg-teal-200 dark:hover:bg-teal-600 shadow-md rounded-lg p-4 cursor-pointer hover:shadow-xl transition-all duration-200 ease-in-out">
         <div className="flex items-center mb-1">
-          <div className="w-20 h-20 bg-gray-300 dark:bg-gray-900 rounded-full flex-shrink-0"></div>
+          <div className="w-20 h-20 bg-gray-500 dark:bg-gray-900 rounded-full flex-shrink-0"></div>
           <div className="ml-4">
             <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
               {name || "name"}

--- a/src/components/AdvocateCard.tsx
+++ b/src/components/AdvocateCard.tsx
@@ -1,9 +1,3 @@
-/**
- * advocate card will contain
- * -> name, degree, specialties, years of experience, city
- */
-
-/** what props does this have? Make an interface */
 interface AdvocateCardProps {
   name: string;
   degree: string;
@@ -12,13 +6,13 @@ interface AdvocateCardProps {
   city: string;
 }
 
-const AdvocateCard = ({
+export default function AdvocateCard({
   name,
   degree,
   specialties,
   yearsOfExperience,
   city,
-}: AdvocateCardProps): JSX.Element => {
+}: AdvocateCardProps) {
   const mockSpecialties: string[] = [
     "Bipolar",
     "LGBTQ",
@@ -32,72 +26,63 @@ const AdvocateCard = ({
     "Personal growth",
     "Substance use/abuse",
     "Pediatrics",
-    // "Women's issues (post-partum, infertility, family planning)",
-    // "Chronic pain",
-    // "Weight loss & nutrition",
-    // "Eating disorders",
-    // "Diabetic Diet and nutrition",
-    // "Coaching (leadership, career, academic and wellness)",
-    // "Life coaching",
-    // "Obsessive-compulsive disorders",
-    // "Neuropsychological evaluations & testing (ADHD testing)",
-    // "Attention and Hyperactivity (ADHD)",
-    // "Sleep issues",
-    // "Schizophrenia and psychotic disorders",
-    // "Learning disorders",
-    // "Domestic abuse",
+  ];
+
+  const mockSpecialties_alt = [
+    "Women's issues (post-partum, infertility, family planning)",
+    "Chronic pain",
+    "Weight loss & nutrition",
+    "Eating disorders",
+    "Diabetic Diet and nutrition",
+    "Coaching (leadership, career, academic and wellness)",
+    "Life coaching",
+    "Obsessive-compulsive disorders",
+    "Neuropsychological evaluations & testing (ADHD testing)",
+    "Attention and Hyperactivity (ADHD)",
+    "Sleep issues",
+    "Schizophrenia and psychotic disorders",
+    "Learning disorders",
+    "Domestic abuse",
   ];
 
   return (
-    <div>
-      <h1>Advocate Card</h1>
-      <div className="bg-white dark:bg-gray-200 shadow-xs rounded-lg p-4 hover:shadow-lg transition-all duration-1000 ease-in-out">
-        {/* Avatar and advocate info */}
+    <>
+      <div className="mb-7"></div>
+      <div className="bg-white dark:bg-gray-600 shadow-md rounded-lg p-4 hover:shadow-lg transition-all duration-200 ease-in-out">
         <div className="flex items-center mb-4">
-          {/* maintain size even if parent becomes smaller */}
-          <div className="w-16 h-16 bg-gray-500 dark:bg-gray-700 rounded-full flex-shrink-0">
-            avatar
-          </div>
-          <div className="bg-gray-200 ml-4">
-            <h2 className="text-lg font-bold text-gray-800 dark:text-gray-800">
+          <div className="w-16 h-16 bg-gray-300 dark:bg-gray-900 rounded-full flex-shrink-0"></div>
+          <div className="ml-4">
+            <h2 className="text-lg font-bold text-gray-800 dark:text-gray-100">
               {name || "name"}
             </h2>
-            <p className="text-sm text-gray-500 dark:text-gray-600">
+            <p className="text-sm text-gray-500 dark:text-gray-300">
               {degree || "degree"}
             </p>
-            <p className="text-sm text-gray-500 dark:text-gray-600">
+            <p className="text-sm text-gray-500 dark:text-gray-300">
               {city || "city"}
             </p>
           </div>
         </div>
-
-        {/* Specialty tags */}
         <div className="mb-4">
-          <h3 className="text-sm font-semibold mb-2 text-teal-800 dark:text-teal-900">
+          <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100 mb-2">
             Specialties
           </h3>
-          <div className="flex flex-wrap p-3 gap-2">
+          <div className="flex flex-wrap gap-2">
             {mockSpecialties &&
-              mockSpecialties.map((specialty: string, index: number) => {
-                return (
-                  <span
-                    key={index}
-                    className="px-2 py-1 bg-teal-100 dark:bg-teal-700 text-teal-1000 dark:text-teal-100 rounded text-xs"
-                  >
-                    {specialty}
-                  </span>
-                );
-              })}
+              mockSpecialties.map((specialty, index) => (
+                <span
+                  key={index}
+                  className="px-2 py-1 bg-teal-100 dark:bg-teal-700 text-teal-800 dark:text-teal-100 rounded text-xs"
+                >
+                  {specialty}
+                </span>
+              ))}
           </div>
         </div>
-
-        {/* Years of experience */}
-        <p className="text-sm text-gray-600 dark:text-gray-900">
-          {yearsOfExperience || "yearsOfExperience: "} years of experience
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          {yearsOfExperience} years of experience
         </p>
       </div>
-    </div>
+    </>
   );
-};
-
-export default AdvocateCard;
+}

--- a/src/components/AdvocateList.tsx
+++ b/src/components/AdvocateList.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import AdvocateCard from "./AdvocateCard";
+
+/** type interface */
+import { Advocate } from "@/types/advocates";
+/** create a type interface */
+
+interface AdvocateListProps {
+  advocates: Advocate[];
+}
+
+/**
+ * A functional component that renders a list of AdvocateCard components.
+ *
+ * @returns A JSX.Element representing the AdvocateList component.
+ */
+const AdvocateList = ({ advocates }: AdvocateListProps): JSX.Element => {
+  console.log("<AdvocateList :: advocate", advocates);
+  return (
+    <>
+      <div>
+        <h1>Advocate List!</h1>
+        {advocates &&
+          advocates.map((advocate, index) => {
+            return (
+              <>
+                <AdvocateCard
+                  key={advocate.id}
+                  name={`${advocate.firstName || "?"} ${
+                    advocate.lastName || "?"
+                  }`}
+                  degree={advocate.degree}
+                  specialties={advocate.specialties}
+                  yearsOfExperience={advocate.yearsOfExperience}
+                  city={advocate.city}
+                />
+              </>
+            );
+            // return <div key={index}>{index} testing</div>;
+          })}
+      </div>
+    </>
+  );
+};
+
+export default AdvocateList;

--- a/src/components/AdvocateList.tsx
+++ b/src/components/AdvocateList.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import AdvocateCard from "./AdvocateCard";
 
 /** type interface */
 import { Advocate } from "@/types/advocates";
-/** create a type interface */
 
+/** create a type interface */
 interface AdvocateListProps {
   advocates: Advocate[];
 }
@@ -12,32 +11,24 @@ interface AdvocateListProps {
 /**
  * A functional component that renders a list of AdvocateCard components.
  *
- * @returns A JSX.Element representing the AdvocateList component.
+ * @param {AdvocateListProps} props - A props object with an `advocates` property.
+ * @returns {JSX.Element} A JSX.Element representing the AdvocateList component.
  */
 const AdvocateList = ({ advocates }: AdvocateListProps): JSX.Element => {
-  console.log("<AdvocateList :: advocate", advocates);
   return (
     <>
-      <div>
-        <h1>Advocate List!</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
         {advocates &&
-          advocates.map((advocate, index) => {
-            return (
-              <>
-                <AdvocateCard
-                  key={advocate.id}
-                  name={`${advocate.firstName || "?"} ${
-                    advocate.lastName || "?"
-                  }`}
-                  degree={advocate.degree}
-                  specialties={advocate.specialties}
-                  yearsOfExperience={advocate.yearsOfExperience}
-                  city={advocate.city}
-                />
-              </>
-            );
-            // return <div key={index}>{index} testing</div>;
-          })}
+          advocates.map((advocate) => (
+            <AdvocateCard
+              key={advocate.id}
+              name={`${advocate.firstName || "?"} ${advocate.lastName || "?"}`}
+              degree={advocate.degree}
+              specialties={advocate.specialties}
+              yearsOfExperience={advocate.yearsOfExperience}
+              city={advocate.city}
+            />
+          ))}
       </div>
     </>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ const Navbar = (): JSX.Element => {
   return (
     <header className="py-4 shadow bg-white">
       <div className="max-w-7xl mx-auto flex justify-between items-center">
-        <h1 className="logo text-2xl font-bold">Advocatr</h1>
+        <h1 className="logo text-4xl font-bold">Advocatr</h1>
         <DarkModeToggle handleToggle={toggleDarkTheme} />
       </div>
     </header>

--- a/src/tests/AdvocateCard.test.tsx
+++ b/src/tests/AdvocateCard.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AdvocateCard from "@/components/AdvocateCard";
+
+describe("AdvocateCard Component", () => {
+  test("renders advocate details", () => {
+    render(
+      <AdvocateCard
+        name="John Doe"
+        degree="MD"
+        specialties={["Cardiology", "Neurology"]}
+        yearsOfExperience={10}
+        city="New York"
+      />
+    );
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("MD")).toBeInTheDocument();
+    expect(screen.getByText("New York")).toBeInTheDocument();
+    expect(screen.getByText("Cardiology")).toBeInTheDocument();
+    expect(screen.getByText("10 years of experience")).toBeInTheDocument();
+  });
+});

--- a/src/tests/AdvocateList.test.tsx
+++ b/src/tests/AdvocateList.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import AdvocateList from "@/components/AdvocateList";
+
+import { Advocate } from "@/types/advocates";
+
+describe("AdvocateList Component", () => {
+  test("renders a list of advocates", () => {
+    const advocates = [
+      {
+        id: 1,
+        firstName: "John",
+        lastName: "Doe",
+        degree: "MD",
+        specialties: ["Cardiology"],
+        yearsOfExperience: 10,
+        city: "New York",
+      },
+      {
+        id: 2,
+        firstName: "Jane",
+        lastName: "Smith",
+        degree: "PhD",
+        specialties: ["Psychology"],
+        yearsOfExperience: 5,
+        city: "Los Angeles",
+      },
+    ];
+
+    render(<AdvocateList advocates={advocates as Advocate[]} />);
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+  });
+});

--- a/src/types/advocates.ts
+++ b/src/types/advocates.ts
@@ -1,0 +1,10 @@
+export interface Advocate {
+  id: number;
+  firstName: string;
+  lastName: string;
+  city: string;
+  degree: string;
+  specialties: string[];
+  yearsOfExperience: number;
+  phoneNumber: number;
+}


### PR DESCRIPTION
### What this PR does:
I implemented an advocates list with responsive cards which replaces the HTML table
- `AdvocateCard` for displaying advocate details
- `AdvocateList` for rendering grids of `AdvocateCards` in a responsive way
- Tests for all new components
- Branded color choices 

### IMPORTANT NOTE:
This PR depends on `PR3: Separate components and implement dark mode #3`. Please review and merge PR3 before reviewing this PR.